### PR TITLE
Use AudioWorklet for playback

### DIFF
--- a/frontend/audio-worklet.js
+++ b/frontend/audio-worklet.js
@@ -1,0 +1,24 @@
+class AudioQueueProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this.buffer = [];
+    this.port.onmessage = (event) => {
+      const chunk = event.data;
+      if (chunk && chunk.length) {
+        // Convert typed array to normal array for easier manipulation
+        this.buffer.push(...chunk);
+      }
+    };
+  }
+
+  process(inputs, outputs) {
+    const output = outputs[0];
+    const channel = output[0];
+    for (let i = 0; i < channel.length; i++) {
+      channel[i] = this.buffer.length ? this.buffer.shift() : 0;
+    }
+    return true;
+  }
+}
+
+registerProcessor('audio-queue-processor', AudioQueueProcessor);

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
 <body>
     <h1>CSM Streaming Demo</h1>
     <button id="ptt">Hold to Talk</button>
-    <script>
+    <script type="module">
         const ws = new WebSocket("ws://localhost:8000/ws");
         let mediaRecorder;
         let audioChunks = [];
@@ -44,16 +44,17 @@
         }
 
         const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+        await audioCtx.audioWorklet.addModule('audio-worklet.js');
+        const playerNode = new AudioWorkletNode(audioCtx, 'audio-queue-processor');
+        playerNode.connect(audioCtx.destination);
+
         ws.onmessage = async event => {
             const data = JSON.parse(event.data);
             if (data.audio_chunk) {
                 const response = await fetch('data:audio/wav;base64,' + data.audio_chunk);
                 const arrayBuffer = await response.arrayBuffer();
                 const audioBuffer = await audioCtx.decodeAudioData(arrayBuffer);
-                const source = audioCtx.createBufferSource();
-                source.buffer = audioBuffer;
-                source.connect(audioCtx.destination);
-                source.start();
+                playerNode.port.postMessage(audioBuffer.getChannelData(0));
             }
         };
     </script>


### PR DESCRIPTION
## Summary
- implement a simple audio worklet processor for streaming
- switch the frontend script to use AudioWorkletNode

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'numpy')*